### PR TITLE
extend Closeable interface in SparkeyReader/Writer

### DIFF
--- a/src/main/java/com/spotify/sparkey/SparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/SparkeyReader.java
@@ -15,11 +15,12 @@
  */
 package com.spotify.sparkey;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 
-public interface SparkeyReader extends Iterable<SparkeyReader.Entry> {
+public interface SparkeyReader extends Iterable<SparkeyReader.Entry>, Closeable {
   /**
    * @param key the key to search for, interpreted as an UTF-8 string.
    * @return null if the key/value pair was not found, otherwise the value interpreted as an UTF-8 string.

--- a/src/main/java/com/spotify/sparkey/SparkeyWriter.java
+++ b/src/main/java/com/spotify/sparkey/SparkeyWriter.java
@@ -15,10 +15,11 @@
  */
 package com.spotify.sparkey;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 
-public interface SparkeyWriter {
+public interface SparkeyWriter extends Closeable {
   /**
    * Append the key/value pair to the writer, as UTF-8.
    */


### PR DESCRIPTION
this should allow the interfaces to be used in try-with-resources blocks in Java 1.8:

```
try (SparkeyReader reader = Sparkey.open(file)) {
    ...
}
```
