### PR TITLE
Fix file append bug on windows platform

### DIFF
--- a/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
+++ b/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
@@ -135,6 +135,20 @@ public class CorrectnessTest extends BaseSystemTest {
     }
     reader.close();
   }
+  
+  @Test
+  public void testAppendedPut() throws IOException {
+    for (int i = 0; i <2; i++) {
+      SparkeyWriter writer = Sparkey.appendOrCreate(indexFile, CompressionType.NONE, 40);
+      writer.put("Key" + i, "Value" + i);
+      writer.flush();
+      writer.writeHash();
+      writer.close();
+    }
+    SparkeyReader reader = Sparkey.open(indexFile);
+    assertEquals("Value1", reader.getAsString("Key1"));
+    reader.close();
+  }
 
   @Test
   public void testWithDeletes() throws IOException {


### PR DESCRIPTION
- On Windows 7 rename can fail if destination exists.
- This would probably not occur with newer api 'move' with java 7 onwards. But sparkey-java intends to support Java 6.
For more details: http://docs.oracle.com/javase/tutorial/essential/io/legacy.html#interop
- Added test case to cover this scenario.