### PR TITLE
Fix file append bug on windows platform

### DIFF
--- a/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyWriter.java
+++ b/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyWriter.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.UUID;
 
 final class SingleThreadedSparkeyWriter implements SparkeyWriter {
   private final LogWriter logWriter;
@@ -85,7 +86,7 @@ final class SingleThreadedSparkeyWriter implements SparkeyWriter {
     flush();
 
     File parentFile = indexFile.getCanonicalFile().getParentFile();
-    File newFile = new File(parentFile, indexFile.getName() + "-tmp" + System.currentTimeMillis());
+    File newFile = new File(parentFile, indexFile.getName() + "-tmp" + UUID.randomUUID().toString());
     try {
       IndexHash.createNew(newFile, logFile, hashType, sparsity, fsync);
       boolean successful = newFile.renameTo(indexFile);

--- a/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyWriter.java
+++ b/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyWriter.java
@@ -89,7 +89,7 @@ final class SingleThreadedSparkeyWriter implements SparkeyWriter {
     File newFile = new File(parentFile, indexFile.getName() + "-tmp" + UUID.randomUUID().toString());
     try {
       IndexHash.createNew(newFile, logFile, hashType, sparsity, fsync);
-      boolean successful = newFile.renameTo(indexFile);
+      boolean successful = Util.renameFile(newFile, indexFile);
       if (!successful) {
         throw new IOException("Could not rename " + newFile + " to " + indexFile);
       }

--- a/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
+++ b/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
@@ -15,7 +15,13 @@
  */
 package com.spotify.sparkey.system;
 
-import com.spotify.sparkey.*;
+import com.spotify.sparkey.CompressionType;
+import com.spotify.sparkey.HashType;
+import com.spotify.sparkey.Sparkey;
+import com.spotify.sparkey.SparkeyLogIterator;
+import com.spotify.sparkey.SparkeyReader;
+import com.spotify.sparkey.SparkeyWriter;
+
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -133,6 +139,20 @@ public class CorrectnessTest extends BaseSystemTest {
       }
       assertEquals("Value" + i, entry.getValueAsString());
     }
+    reader.close();
+  }
+
+  @Test
+  public void testAppendedPut() throws IOException {
+    for (int i = 0; i <2; i++) {
+      SparkeyWriter writer = Sparkey.appendOrCreate(indexFile, CompressionType.NONE, 40);
+      writer.put("Key" + i, "Value" + i);
+      writer.flush();
+      writer.writeHash();
+      writer.close();
+    }
+    SparkeyReader reader = Sparkey.open(indexFile);
+    assertEquals("Value1", reader.getAsString("Key1"));
     reader.close();
   }
 


### PR DESCRIPTION
- On Windows 7 rename can fail if destination exists.
- This would probably not occur with newer api 'move' with java 7 onwards. But sparkey-java intends to support Java 6.
For more details: http://docs.oracle.com/javase/tutorial/essential/io/legacy.html#interop
- Added test case to cover this scenario.

(Fix originally submitted by https://github.com/tejaspathak - this is a slight refactoring of it)