### PR TITLE
Bump up snappy-java version to 1.1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.0-M3</version>
+      <version>1.1.2.1</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Version 1.1.0-M3 was causing issues regarding the loading and injection of the native Snappy library.
The issue appeared within a web application (.war) deployed on the Wildfly (9.0.2) app server.