### PR TITLE
Support different cleaner strategies

### DIFF
--- a/src/main/java/com/spotify/sparkey/Sparkey.java
+++ b/src/main/java/com/spotify/sparkey/Sparkey.java
@@ -15,6 +15,8 @@
  */
 package com.spotify.sparkey;
 
+import com.spotify.sparkey.cleaner.MappedByteBufferCleaner;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -167,5 +169,9 @@ public final class Sparkey {
    */
   public static LogHeader getLogHeader(File file) throws IOException {
     return LogHeader.read(file);
+  }
+
+  public static void setMappedByteBufferCleaner(MappedByteBufferCleaner cleaner) {
+    ReadOnlyMemMap.setCleaner(cleaner);
   }
 }

--- a/src/main/java/com/spotify/sparkey/cleaner/ByteBufferCleaner.java
+++ b/src/main/java/com/spotify/sparkey/cleaner/ByteBufferCleaner.java
@@ -1,4 +1,4 @@
-package com.spotify.sparkey;
+package com.spotify.sparkey.cleaner;
 
 import java.io.IOException;
 import java.lang.reflect.Method;

--- a/src/main/java/com/spotify/sparkey/cleaner/DirectCleaner.java
+++ b/src/main/java/com/spotify/sparkey/cleaner/DirectCleaner.java
@@ -1,0 +1,12 @@
+package com.spotify.sparkey.cleaner;
+
+import java.nio.MappedByteBuffer;
+
+public class DirectCleaner implements MappedByteBufferCleaner {
+    @Override
+    public void cleanup(MappedByteBuffer... chunks) {
+        for (MappedByteBuffer chunk : chunks) {
+            ByteBufferCleaner.cleanMapping(chunk);
+        }
+    }
+}

--- a/src/main/java/com/spotify/sparkey/cleaner/MappedByteBufferCleaner.java
+++ b/src/main/java/com/spotify/sparkey/cleaner/MappedByteBufferCleaner.java
@@ -1,0 +1,7 @@
+package com.spotify.sparkey.cleaner;
+
+import java.nio.MappedByteBuffer;
+
+public interface MappedByteBufferCleaner {
+    void cleanup(MappedByteBuffer... chunks);
+}

--- a/src/main/java/com/spotify/sparkey/cleaner/SingleThreadedCleanerWithWait.java
+++ b/src/main/java/com/spotify/sparkey/cleaner/SingleThreadedCleanerWithWait.java
@@ -1,0 +1,33 @@
+package com.spotify.sparkey.cleaner;
+
+import java.nio.MappedByteBuffer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+public class SingleThreadedCleanerWithWait implements MappedByteBufferCleaner {
+    private static final ScheduledExecutorService CLEANER = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r);
+            thread.setName(SingleThreadedCleanerWithWait.class.getSimpleName() + "-cleaner");
+            thread.setDaemon(true);
+            return thread;
+        }
+    });
+
+    @Override
+    public void cleanup(final MappedByteBuffer... chunks) {
+        // Wait a bit with closing so that all threads have a chance to see the that
+        // chunks and curChunks are null
+        CLEANER.schedule(new Runnable() {
+            @Override
+            public void run() {
+                for (MappedByteBuffer chunk : chunks) {
+                    ByteBufferCleaner.cleanMapping(chunk);
+                }
+            }
+        }, 1000, TimeUnit.MILLISECONDS);
+    }
+}


### PR DESCRIPTION
Refactor to support the direct closing of the MappedByteBuffers and to solve issue #27.
The closing/cleanup is moved out of the `ReadOnlyMemMap ` into separate cleaner classes.

The current behaviour with a single threaded executor, which is used to schedule the cleanup with a 1 second delay, is implemented in `SingleThreadedCleanerWithWait` and kept as the default.

But this default can lead to a severe issue (#27), if we create many readers very fast.
Even if we close them directly after we created them, the memory will be freed only after 1 second at the earliest. Even worse is the fact that we can create readers much faster (with multiple threads) than the single threaded executor can do the cleanup. With high enough rates we can use up the virtual memory space, resulting in an `OutOfMemory` exception.

As we do not share the (not thread safe) readers between threads, we want the cleanup to happen as soon as we close the reader. So the memory is freed as soon as possible (and the caller thread is blocked).
This is implemented with the `DirectCleaner`.

To use the `DirectCleaner` instead of the default behaviour, you have to set a `DirectCleaner` instance as the cleaner to be used by `ReadOnlyMemMap`.
This can (currently) only be done globally and not per reader via the `setMappedByteBufferCleaner` method.