### PR TITLE
make Sparkey.open(...) default to thread safe

### DIFF
--- a/src/main/java/com/spotify/sparkey/Sparkey.java
+++ b/src/main/java/com/spotify/sparkey/Sparkey.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.sparkey;
 
+import com.spotify.sparkey.extra.ThreadLocalSparkeyReader;
 import java.io.File;
 import java.io.IOException;
 
@@ -76,6 +77,17 @@ public final class Sparkey {
   }
 
   /**
+   * Open a new, thread-safe, sparkey reader
+   *
+   *
+   * @param file File base to use, the actual file endings will be set to .spi and .spl
+   * @return a new reader,
+   */
+  public static SparkeyReader open(File file) throws IOException {
+    return new ThreadLocalSparkeyReader(file);
+  }
+
+  /**
    * Open a new sparkey reader
    *
    * This is not a thread-safe class, only use it from one thread.
@@ -83,7 +95,7 @@ public final class Sparkey {
    * @param file File base to use, the actual file endings will be set to .spi and .spl
    * @return a new reader,
    */
-  public static SparkeyReader open(File file) throws IOException {
+  public static SparkeyReader openSingleThreadReader(File file) throws IOException {
     return SingleThreadedSparkeyReader.open(file);
   }
 

--- a/src/main/java/com/spotify/sparkey/Sparkey.java
+++ b/src/main/java/com/spotify/sparkey/Sparkey.java
@@ -88,6 +88,17 @@ public final class Sparkey {
   }
 
   /**
+   * Open a new, thread-safe, sparkey reader
+   *
+   *
+   * @param file File base to use, the actual file endings will be set to .spi and .spl
+   * @return a new reader,
+   */
+  public static SparkeyReader openThreadLocalReader(File file) throws IOException {
+    return new ThreadLocalSparkeyReader(file);
+  }
+
+  /**
    * Open a new sparkey reader
    *
    * This is not a thread-safe class, only use it from one thread.
@@ -95,7 +106,7 @@ public final class Sparkey {
    * @param file File base to use, the actual file endings will be set to .spi and .spl
    * @return a new reader,
    */
-  public static SparkeyReader openSingleThreadReader(File file) throws IOException {
+  public static SparkeyReader openSingleThreadedReader(File file) throws IOException {
     return SingleThreadedSparkeyReader.open(file);
   }
 

--- a/src/main/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReader.java
@@ -33,7 +33,7 @@ public class ThreadLocalSparkeyReader extends AbstractDelegatingSparkeyReader {
   private volatile ThreadLocal<SparkeyReader> threadLocalReader;
 
   public ThreadLocalSparkeyReader(File indexFile) throws IOException {
-    this(Sparkey.openSingleThreadReader(indexFile));
+    this(Sparkey.openSingleThreadedReader(indexFile));
   }
 
   public ThreadLocalSparkeyReader(final SparkeyReader reader) {

--- a/src/main/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReader.java
@@ -33,7 +33,7 @@ public class ThreadLocalSparkeyReader extends AbstractDelegatingSparkeyReader {
   private volatile ThreadLocal<SparkeyReader> threadLocalReader;
 
   public ThreadLocalSparkeyReader(File indexFile) throws IOException {
-    this(Sparkey.open(indexFile));
+    this(Sparkey.openSingleThreadReader(indexFile));
   }
 
   public ThreadLocalSparkeyReader(final SparkeyReader reader) {


### PR DESCRIPTION
A few times, I've noticed Sparkey users assume `Sparkey.open(...)` is thread safe (fair assumption, IMHO, since the index is read-only).
@spkrka Any reason to not do this?
