### PR TITLE
Don't stack overflow on very large writes

### DIFF
--- a/src/main/java/com/spotify/sparkey/SnappyOutputStream.java
+++ b/src/main/java/com/spotify/sparkey/SnappyOutputStream.java
@@ -74,15 +74,24 @@ final class SnappyOutputStream extends OutputStream {
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
+    while (len > 0) {
+      int written = writeImpl(b, off, len);
+      off += written;
+      len -= written;
+    }
+  }
+
+  private int writeImpl(byte[] b, int off, int len) throws IOException {
     int remaining = remaining();
     if (len < remaining) {
       System.arraycopy(b, off, uncompressedBuffer, pending, len);
       pending += len;
+      return len;
     } else {
       System.arraycopy(b, off, uncompressedBuffer, pending, remaining);
       pending = maxBlockSize;
       flush();
-      write(b, off + remaining, len - remaining);
+      return remaining;
     }
   }
 

--- a/src/test/java/com/spotify/sparkey/SnappyOutputStreamTest.java
+++ b/src/test/java/com/spotify/sparkey/SnappyOutputStreamTest.java
@@ -1,0 +1,24 @@
+package com.spotify.sparkey;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+
+/**
+ * Tests SnappyOutputStream
+ */
+public class SnappyOutputStreamTest {
+    @Test
+    public void testLargeWrite() throws IOException {
+        File testFile = File.createTempFile("sparkey-test", "");
+        testFile.deleteOnExit();
+        FileOutputStream fos = new FileOutputStream(testFile);
+
+        byte[] buf = new byte[1000 * 1000];
+        SnappyOutputStream os = new SnappyOutputStream(10, fos, fos.getFD());
+        os.write(buf);
+
+        testFile.delete();
+    }
+}

--- a/src/test/java/com/spotify/sparkey/SnappyReaderTest.java
+++ b/src/test/java/com/spotify/sparkey/SnappyReaderTest.java
@@ -1,0 +1,76 @@
+package com.spotify.sparkey;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.xerial.snappy.Snappy;
+
+import java.io.*;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests SnappyReader
+ */
+public class SnappyReaderTest {
+    // A stream that reads the same array repeatedly, forever.
+    private class RepeatingInputStream extends InputStream {
+        private byte[] buffer;
+        private int pos = 0;
+
+        public RepeatingInputStream(byte[] buf) throws IOException {
+            buffer = buf;
+        }
+
+        public int read() throws IOException {
+            int ret = buffer[pos];
+            skip(1);
+            return ret;
+        }
+
+        public int read(byte[] b, int off, int len) throws IOException {
+            int remain = len;
+            while (remain > 0) {
+                int avail = buffer.length - pos;
+                int copy = Math.min(avail, remain);
+                System.arraycopy(buffer, pos, b, off, copy);
+                skip(copy);
+                off += copy;
+                remain -= copy;
+            }
+            return len;
+        }
+
+        public long skip(long n) throws IOException {
+            pos = (int)((n + pos) % buffer.length);
+            return n;
+        }
+    }
+
+    private SnappyReader reader() throws IOException {
+        byte[] uncompressed = new byte[10];
+        for (int i = 0; i < uncompressed.length; ++i) {
+            uncompressed[i] = (byte)i;
+        }
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        byte[] compressed = Snappy.compress(uncompressed);
+        Util.writeUnsignedVLQ(compressed.length, bytes);
+        bytes.write(compressed);
+
+        InputStream buf = new RepeatingInputStream(bytes.toByteArray());
+        return new SnappyReader(buf, uncompressed.length, 0);
+    }
+
+    @Test
+    public void testLargeSkip() throws IOException {
+        long ret = reader().skip(1000 * 1000);
+        assertEquals(1000 * 1000, ret);
+    }
+
+    @Test
+    public void testLargeRead() throws IOException {
+        byte[] buf = new byte[1000 * 1000];
+        int ret = reader().read(buf);
+        assertEquals(1000 * 1000, ret);
+    }
+}


### PR DESCRIPTION
`SnappyOutputStream.write(byte[] b, int off, int len)` currently recurses when there's not enough space in the current Snappy buffer for all data. This causes a StackOverflowError on very large writes.

This patch iterates instead of recursing. The added test tests a large write / block-size ratio, to verify that it solves the problem.

Similar for read and skip in SnappyReader.