### PR TITLE
Optimize hash reads by reading from mmap getInt/getLong instead of individual bytes

### DIFF
--- a/src/main/java/com/spotify/sparkey/AddressSize.java
+++ b/src/main/java/com/spotify/sparkey/AddressSize.java
@@ -21,7 +21,7 @@ enum AddressSize {
   LONG() {
     @Override
     long readAddress(RandomAccessData data) throws IOException {
-      return Util.readLittleEndianLong(data);
+      return data.readLittleEndianLong();
     }
 
     @Override
@@ -32,7 +32,7 @@ enum AddressSize {
   INT() {
     @Override
     long readAddress(RandomAccessData data) throws IOException {
-      return Util.readLittleEndianInt(data) & INT_MASK;
+      return data.readLittleEndianInt() & INT_MASK;
     }
 
     @Override

--- a/src/main/java/com/spotify/sparkey/HashType.java
+++ b/src/main/java/com/spotify/sparkey/HashType.java
@@ -21,7 +21,7 @@ public enum HashType {
   HASH_64_BITS(8) {
     @Override
     long readHash(RandomAccessData data) throws IOException {
-      return Util.readLittleEndianLong(data);
+      return data.readLittleEndianLong();
     }
 
     @Override
@@ -37,7 +37,7 @@ public enum HashType {
   HASH_32_BITS(4) {
     @Override
     long readHash(RandomAccessData data) throws IOException {
-      return Util.readLittleEndianInt(data) & INT_MASK;
+      return data.readLittleEndianInt() & INT_MASK;
     }
 
     @Override

--- a/src/main/java/com/spotify/sparkey/RandomAccessData.java
+++ b/src/main/java/com/spotify/sparkey/RandomAccessData.java
@@ -19,4 +19,8 @@ import java.io.IOException;
 
 interface RandomAccessData {
   int readUnsignedByte() throws IOException;
+
+  int readLittleEndianInt() throws IOException;
+
+  long readLittleEndianLong() throws IOException;
 }

--- a/src/main/java/com/spotify/sparkey/Util.java
+++ b/src/main/java/com/spotify/sparkey/Util.java
@@ -65,7 +65,7 @@ final class Util {
     writeLittleEndianInt((int) (value >>> 32), rw);
   }
 
-  static long readLittleEndianLong(RandomAccessData data) throws IOException {
+  static long readLittleEndianLongSlowly(RandomAccessData data) throws IOException {
     long res = (long) data.readUnsignedByte();
     res |= ((long) data.readUnsignedByte()) << 8;
     res |= ((long) data.readUnsignedByte()) << 16;
@@ -84,7 +84,7 @@ final class Util {
             input) << 48 | (long) readByte(input) << 56;
   }
 
-  static int readLittleEndianInt(RandomAccessData data) throws IOException {
+  static int readLittleEndianIntSlowly(RandomAccessData data) throws IOException {
     int a = data.readUnsignedByte();
     int b = data.readUnsignedByte();
     int c = data.readUnsignedByte();


### PR DESCRIPTION
```
               Benchmark                      (numElements) (type)   Mode   Samples         Mean   Mean error    Units
Before change: c.s.s.s.LookupBenchmark.test         1000000   NONE  thrpt        50  2019320.933    39523.924    ops/s
After change:  c.s.s.s.LookupBenchmark.test         1000000   NONE  thrpt        50  2126920.290    58892.998    ops/s
```