### PR TITLE
Clean up bytebuffers immediately when closing a ReadWriteMemMap

### DIFF
--- a/src/main/java/com/spotify/sparkey/IndexHash.java
+++ b/src/main/java/com/spotify/sparkey/IndexHash.java
@@ -161,13 +161,11 @@ final class IndexHash {
   private static void writeIndexWithSorting(final File indexFile, final File logFile, final boolean fsync, final LogHeader logHeader,
                                             final IndexHeader header, final long hashLength, final long maxMemory) throws IOException {
     //ReadWriteData indexData2 = new FileReadWriteData(hashLength, indexFile2, header2, fsync);
-    ReadWriteData indexData2 = new ReadWriteMemMap(hashLength, indexFile, header, fsync);
-    long t3 = System.currentTimeMillis();
-    fillFromLogSorted(indexData2, logFile, header, logHeader.size(), header.getDataEnd(),
+    ReadWriteData indexData = new ReadWriteMemMap(hashLength, indexFile, header, fsync);
+    fillFromLogSorted(indexData, logFile, header, logHeader.size(), header.getDataEnd(),
         logHeader, maxMemory);
-    long t4 = System.currentTimeMillis();
-    calculateMaxDisplacement(header, indexData2);
-    indexData2.close();
+    calculateMaxDisplacement(header, indexData);
+    indexData.close();
   }
 
   private static void writeIndexInMemory(final File indexFile, final File logFile, final boolean fsync, final LogHeader logHeader,
@@ -176,10 +174,8 @@ final class IndexHash {
     //ReadWriteData indexData = new FileReadWriteData(hashLength, indexFile, header, fsync);
     //ReadWriteData indexData = new ReadWriteMemMap(hashLength, indexFile, header, fsync);
 
-    long t1 = System.currentTimeMillis();
     fillFromLog(indexData, logFile, header, logHeader.size(), header.getDataEnd(),
         logHeader);
-    long t2 = System.currentTimeMillis();
     calculateMaxDisplacement(header, indexData);
     indexData.close();
 

--- a/src/main/java/com/spotify/sparkey/ReadWriteMemMap.java
+++ b/src/main/java/com/spotify/sparkey/ReadWriteMemMap.java
@@ -125,16 +125,12 @@ final class ReadWriteMemMap implements ReadWriteData {
     curChunk = null;
     Util.nonThrowingClose(randomAccessFile);
 
-    // Wait a bit with closing so that all threads have a chance to see the that
-    // chunks and curChunks are null
-    ReadOnlyMemMap.CLEANER.schedule(new Runnable() {
-      @Override
-      public void run() {
-        for (MappedByteBuffer chunk : chunks) {
-          ByteBufferCleaner.cleanMapping(chunk);
-        }
-      }
-    }, 1000, TimeUnit.MILLISECONDS);
+    // Clean it up immediately since this should only be used from a single thread anyway
+    for (int i = 0; i < chunks.length; i++) {
+      final MappedByteBuffer byteBuffer = chunks[i];
+      chunks[i] = null;
+      ByteBufferCleaner.cleanMapping(byteBuffer);
+    }
   }
 
   @Override


### PR DESCRIPTION
This fixes https://github.com/spotify/sparkey-java/issues/34
"ConstructionMethod.SORTING on windows prevents renaming .spi file"