### PR TITLE
Improve windows support

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -7,8 +7,3 @@ Spotify AB (http://www.spotify.com/).
 This project includes MurmurHash3, written by Austin Appleby, which is
 placed in the public domain. The original software is available from
   https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
-
-This project includes some code (ByteBufferCleaner) from Apache Lucene 3.6
-from the Apache Software Foundation (ASF). The code is licensed with
-Apache Licence 2.0
-

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,18 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.spotify.sparkey</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/src/main/java/com/spotify/sparkey/BlockRandomInput.java
+++ b/src/main/java/com/spotify/sparkey/BlockRandomInput.java
@@ -31,4 +31,5 @@ interface BlockRandomInput {
 
   BlockRandomInput duplicate();
 
+  void closeDuplicate();
 }

--- a/src/main/java/com/spotify/sparkey/HashType.java
+++ b/src/main/java/com/spotify/sparkey/HashType.java
@@ -66,7 +66,7 @@ public enum HashType {
   private static final long INT_MASK = (1L << 32) - 1;
   private final int size;
 
-  private HashType(int size) {
+  HashType(int size) {
     this.size = size;
   }
 

--- a/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyReader.java
@@ -81,7 +81,7 @@ final class SingleThreadedSparkeyReader implements SparkeyReader {
 
   /**
    * @return a new iterator that can be safely used from a single thread.
-   * Note that antries will be reused and modified, so any data you want from it must be consumed before
+   * Note that entries will be reused and modified, so any data you want from it must be consumed before
    * continuing iteration. You should not pass this entry on in any way.
    */
   @Override
@@ -121,6 +121,8 @@ final class SingleThreadedSparkeyReader implements SparkeyReader {
             }
           }
         }
+        indexHash.closeDuplicate();
+
         return false;
       }
 

--- a/src/main/java/com/spotify/sparkey/SnappyRandomReader.java
+++ b/src/main/java/com/spotify/sparkey/SnappyRandomReader.java
@@ -114,4 +114,9 @@ final class SnappyRandomReader implements BlockRandomInput {
     return duplicate;
   }
 
+  @Override
+  public void closeDuplicate() {
+    data.closeDuplicate();
+  }
+
 }

--- a/src/main/java/com/spotify/sparkey/SortHelper.java
+++ b/src/main/java/com/spotify/sparkey/SortHelper.java
@@ -60,7 +60,7 @@ final class SortHelper {
     Sorter<SortHelper.Entry>
         sorter = new Sorter<SortHelper.Entry>(config, readerFactory, ENTRY_DATA_WRITER_FACTORY, ENTRY_COMPARATOR);
 
-    return sorter.sort(new SortHelper.LogFileEntryReader(logFile, start, end, hashData, hashCapacity, hashSeed));
+    return sorter.sort(new LogFileEntryReader(logFile, start, end, hashData, hashCapacity, hashSeed));
   }
 
   private static class EntryDataReader extends DataReader<Entry> {

--- a/src/main/java/com/spotify/sparkey/Sparkey.java
+++ b/src/main/java/com/spotify/sparkey/Sparkey.java
@@ -18,8 +18,15 @@ package com.spotify.sparkey;
 import com.spotify.sparkey.extra.ThreadLocalSparkeyReader;
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class Sparkey {
+  /**
+   * Tracks number of memory mapped files - useful for detecting leaks
+   */
+  private static final AtomicInteger OPEN_MMAPS = new AtomicInteger();
+  private static final AtomicInteger OPEN_FILES = new AtomicInteger();
+
   private Sparkey() {
   }
 
@@ -191,4 +198,29 @@ public final class Sparkey {
   public static LogHeader getLogHeader(File file) throws IOException {
     return LogHeader.read(file);
   }
+
+  static void incrOpenMaps() {
+    OPEN_MMAPS.incrementAndGet();
+  }
+
+  static void decrOpenMaps() {
+    OPEN_MMAPS.decrementAndGet();
+  }
+
+  public static int getOpenMaps() {
+    return OPEN_MMAPS.get();
+  }
+
+  static void incrOpenFiles() {
+    OPEN_FILES.incrementAndGet();
+  }
+
+  static void decrOpenFiles() {
+    OPEN_FILES.decrementAndGet();
+  }
+
+  public static int getOpenFiles() {
+    return OPEN_FILES.get();
+  }
+
 }

--- a/src/main/java/com/spotify/sparkey/SparkeyWriter.java
+++ b/src/main/java/com/spotify/sparkey/SparkeyWriter.java
@@ -16,7 +16,6 @@
 package com.spotify.sparkey;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/src/main/java/com/spotify/sparkey/UncompressedBlockRandomInput.java
+++ b/src/main/java/com/spotify/sparkey/UncompressedBlockRandomInput.java
@@ -53,4 +53,9 @@ class UncompressedBlockRandomInput implements BlockRandomInput {
   public BlockRandomInput duplicate() {
     return new UncompressedBlockRandomInput(data.duplicate());
   }
+
+  @Override
+  public void closeDuplicate() {
+    data.closeDuplicate();
+  }
 }

--- a/src/test/java/com/spotify/sparkey/AddressSizeTest.java
+++ b/src/test/java/com/spotify/sparkey/AddressSizeTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 /**
  * Tests AddressSize
  */
-public class AddressSizeTest {
+public class AddressSizeTest extends OpenMapsAsserter {
 
 
 

--- a/src/test/java/com/spotify/sparkey/BytesWrittenTest.java
+++ b/src/test/java/com/spotify/sparkey/BytesWrittenTest.java
@@ -9,18 +9,20 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
-public class BytesWrittenTest {
+public class BytesWrittenTest extends OpenMapsAsserter {
 
   private File file;
 
   @Before
   public void setUp() throws Exception {
+    super.setUp();
     file = File.createTempFile("sparkey_test_", ".spl");
   }
 
   @After
   public void tearDown() throws Exception {
     file.delete();
+    super.tearDown();
   }
 
   @Test

--- a/src/test/java/com/spotify/sparkey/IndexHashTest.java
+++ b/src/test/java/com/spotify/sparkey/IndexHashTest.java
@@ -1,8 +1,6 @@
 package com.spotify.sparkey;
 
-import com.google.common.io.Files;
-import com.sun.management.UnixOperatingSystemMXBean;
-import org.apache.commons.io.FileUtils;
+import com.spotify.sparkey.system.BaseSystemTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,29 +8,23 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class IndexHashTest {
-  private File dir;
-
+public class IndexHashTest extends BaseSystemTest {
   @Before
   public void setUp() throws Exception {
-    dir = Files.createTempDir();
+    super.setUp();
   }
 
   @After
   public void tearDown() throws Exception {
-    FileUtils.deleteDirectory(dir);
+    super.tearDown();
   }
 
   @Test
   public void testCorruptHashFile() throws Exception {
-    File indexFile = new File(dir, "test.spi");
-
     SparkeyWriter writer = Sparkey.createNew(indexFile, CompressionType.NONE, 1);
     for (int i = 0; i < 100; i++) {
       writer.put("key" + i, "value" + i);
@@ -42,31 +34,23 @@ public class IndexHashTest {
 
     corruptFile(indexFile);
 
-    long before = getFileHandleCount();
+    assertEquals(0, Sparkey.getOpenFiles());
+    assertEquals(0, Sparkey.getOpenMaps());
+
     try {
       Sparkey.open(indexFile);
       fail();
     } catch (Exception e) {
       assertEquals(RuntimeException.class, e.getClass());
     }
-    long after = getFileHandleCount();
 
-    assertEquals(before, after);
-
+    assertEquals(0, Sparkey.getOpenFiles());
+    assertEquals(0, Sparkey.getOpenMaps());
   }
 
   private void corruptFile(File indexFile) throws IOException {
     RandomAccessFile randomAccessFile = new RandomAccessFile(indexFile, "rw");
     randomAccessFile.setLength(randomAccessFile.length() - 100);
     randomAccessFile.close();
-  }
-
-  private static long getFileHandleCount() {
-    OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
-    if(os instanceof UnixOperatingSystemMXBean){
-      long openFileDescriptorCount = ((UnixOperatingSystemMXBean) os).getOpenFileDescriptorCount();
-      return openFileDescriptorCount;
-    }
-    throw new UnsupportedOperationException();
   }
 }

--- a/src/test/java/com/spotify/sparkey/OpenMapsAsserter.java
+++ b/src/test/java/com/spotify/sparkey/OpenMapsAsserter.java
@@ -1,0 +1,22 @@
+package com.spotify.sparkey;
+
+import org.junit.After;
+import org.junit.Before;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+public class OpenMapsAsserter {
+
+  @Before
+  public void setUp() throws Exception {
+    assumeTrue(0 == Sparkey.getOpenMaps());
+    assumeTrue(0 == Sparkey.getOpenFiles());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    assertEquals(0, Sparkey.getOpenMaps());
+    assertEquals(0, Sparkey.getOpenFiles());
+  }
+}

--- a/src/test/java/com/spotify/sparkey/ReadOnlyMemMapTest.java
+++ b/src/test/java/com/spotify/sparkey/ReadOnlyMemMapTest.java
@@ -1,6 +1,7 @@
 package com.spotify.sparkey;
 
 import com.google.common.collect.Lists;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -13,11 +14,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class ReadOnlyMemMapTest {
+public class ReadOnlyMemMapTest extends OpenMapsAsserter {
 
   @Test
   public void testDontRunOutOfFileDescriptors() throws Exception {
-    for (int iter = 0; iter < 10*1000; iter++) {
+    for (int iter = 0; iter < 100; iter++) {
       ReadOnlyMemMap memMap = new ReadOnlyMemMap(new File("README.md"));
       ArrayList<ReadOnlyMemMap> maps = Lists.newArrayList();
       for (int i = 0; i < 100; i++) {
@@ -28,21 +29,22 @@ public class ReadOnlyMemMapTest {
         try {
           map.readUnsignedByte();
           fail();
-        } catch (IOException e) {
+        } catch (SparkeyReaderClosedException e) {
         }
         try {
           map.seek(1);
           fail();
-        } catch (IOException e) {
+        } catch (SparkeyReaderClosedException e) {
         }
         try {
           map.skipBytes(1);
           fail();
-        } catch (IOException e) {
+        } catch (SparkeyReaderClosedException e) {
         }
       }
+      assertEquals(0, Sparkey.getOpenFiles());
+      assertEquals(0, Sparkey.getOpenMaps());
     }
-
   }
 
   @Test

--- a/src/test/java/com/spotify/sparkey/UtilTest.java
+++ b/src/test/java/com/spotify/sparkey/UtilTest.java
@@ -21,6 +21,10 @@ import static org.junit.Assert.fail;
  */
 public class UtilTest {
 
+  public static void setMapBits(int bits) {
+    ReadOnlyMemMap.MAP_SIZE_BITS = bits;
+  }
+
   @Test
   public void testUnsignedByte() {
     assertEquals(0, Util.unsignedByte((byte) 0));

--- a/src/test/java/com/spotify/sparkey/UtilTest.java
+++ b/src/test/java/com/spotify/sparkey/UtilTest.java
@@ -163,6 +163,11 @@ public class UtilTest {
     public BlockRandomInput duplicate() {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void closeDuplicate() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   @Test

--- a/src/test/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReaderTest.java
+++ b/src/test/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReaderTest.java
@@ -8,6 +8,7 @@ import com.spotify.sparkey.SparkeyReader;
 import com.spotify.sparkey.SparkeyWriter;
 import com.spotify.sparkey.system.BaseSystemTest;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -38,6 +39,15 @@ public class ThreadLocalSparkeyReaderTest extends BaseSystemTest {
     writer.close();
 
     reader = new ThreadLocalSparkeyReader(indexFile);
+  }
+
+  @Override
+  @After
+  public void tearDown() throws Exception {
+    if (reader != null) {
+      reader.close();
+    }
+    super.tearDown();
   }
 
   @Test

--- a/src/test/java/com/spotify/sparkey/system/BaseSystemTest.java
+++ b/src/test/java/com/spotify/sparkey/system/BaseSystemTest.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.sparkey.system;
 
+import com.spotify.sparkey.OpenMapsAsserter;
 import com.spotify.sparkey.Sparkey;
 import org.junit.After;
 import org.junit.Before;
@@ -22,12 +23,13 @@ import org.junit.Test;
 
 import java.io.File;
 
-public class BaseSystemTest {
+public class BaseSystemTest extends OpenMapsAsserter {
   protected File indexFile;
   protected File logFile;
 
   @Before
   public void setUp() throws Exception {
+    super.setUp();
     indexFile = File.createTempFile("sparkey", ".spi");
     logFile = Sparkey.getLogFile(indexFile);
     indexFile.deleteOnExit();
@@ -35,9 +37,10 @@ public class BaseSystemTest {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws Exception {
     indexFile.delete();
     logFile.delete();
+    super.tearDown();
   }
 
   @Test

--- a/src/test/java/com/spotify/sparkey/system/BaseSystemTest.java
+++ b/src/test/java/com/spotify/sparkey/system/BaseSystemTest.java
@@ -16,7 +16,9 @@
 package com.spotify.sparkey.system;
 
 import com.spotify.sparkey.OpenMapsAsserter;
+import com.spotify.sparkey.ReadOnlyMemMapTest;
 import com.spotify.sparkey.Sparkey;
+import com.spotify.sparkey.UtilTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +32,7 @@ public class BaseSystemTest extends OpenMapsAsserter {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    UtilTest.setMapBits(10);
     indexFile = File.createTempFile("sparkey", ".spi");
     logFile = Sparkey.getLogFile(indexFile);
     indexFile.deleteOnExit();

--- a/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
+++ b/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
@@ -73,7 +73,11 @@ public class CorrectnessTest extends BaseSystemTest {
       writer.close();
 
       SparkeyReader reader = Sparkey.open(indexFile);
-      assertEquals(expectedValue, reader.getAsString("key"));
+      try {
+        assertEquals(expectedValue, reader.getAsString("key"));
+      } finally {
+        reader.close();
+      }
     }
   }
 
@@ -134,7 +138,7 @@ public class CorrectnessTest extends BaseSystemTest {
 
     TestSparkeyWriter.writeHashAndCompare(writer);
     writer.close();
-
+    assertEquals(0, Sparkey.getOpenFiles());
 
     SparkeyReader reader = Sparkey.open(indexFile);
     for (int i = 0; i < N; i++) {
@@ -178,6 +182,17 @@ public class CorrectnessTest extends BaseSystemTest {
         testHelperWithDeletes(size, CompressionType.SNAPPY, 1024, hashType);
         testHelperWithDeletes(size, CompressionType.SNAPPY, 4096, hashType);
       }
+    }
+  }
+
+  @Test
+  public void testOverwrite() throws IOException {
+    for (int i = 0; i < 10; i++) {
+      SparkeyWriter writer = Sparkey.createNew(indexFile);
+      writer.put("A", "B");
+      writer.flush();
+      TestSparkeyWriter.writeHashAndCompare(writer);
+      writer.close();
     }
   }
 }

--- a/src/test/java/com/spotify/sparkey/system/LargeFilesTest.java
+++ b/src/test/java/com/spotify/sparkey/system/LargeFilesTest.java
@@ -16,20 +16,18 @@
 package com.spotify.sparkey.system;
 
 import com.spotify.sparkey.*;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 
 import static org.junit.Assert.*;
 
-// Ignore since it requires a lot of memory to run.
-@Ignore
 public class LargeFilesTest extends BaseSystemTest {
   @Test
   public void testLargeLogFile() throws IOException {
+    UtilTest.setMapBits(10);
     String expectedValue = "value";
-    while (expectedValue.length() < 1024*1024) {
+    while (expectedValue.length() < 5*1024) { // Larger than a map chunk
       expectedValue += expectedValue;
     }
 
@@ -42,7 +40,7 @@ public class LargeFilesTest extends BaseSystemTest {
     TestSparkeyWriter.writeHashAndCompare(writer);
     writer.close();
 
-    assertTrue(logFile.length() > 2L*1024*1024*1024);
+    assertTrue(logFile.length() > 2000 * 5 * 1024);
     SparkeyReader reader = Sparkey.open(indexFile);
     for (int i = 0; i < 2000; i += 100) {
       assertEquals(expectedValue, reader.getAsString("key_" + i));
@@ -53,17 +51,17 @@ public class LargeFilesTest extends BaseSystemTest {
 
   @Test
   public void testSmallIndexFile() throws IOException {
-    testLargeIndexFileInner(700000);
+    testLargeIndexFileInner(7000);
   }
 
   @Test
   public void testMediumIndexFile() throws IOException {
-    testLargeIndexFileInner(15000000);
+    testLargeIndexFileInner(150000);
   }
 
   @Test
   public void testLargeIndexFile() throws IOException {
-    testLargeIndexFileInner(50000000);
+    testLargeIndexFileInner(500000);
   }
 
   private void testLargeIndexFileInner(final long size) throws IOException {


### PR DESCRIPTION
Make sure to close all files and unmap all mapped memory to avoid
various Windows errors (can't rename, delete or overwrite file).

Closing a reader will now synchronously unmap the memory instead of
running it in the background after a delay. This also means that
shared readers will have an extra 100 ms delay before finishing the
close() operation.

As a side effect this commit also:
* Fixed some bugs with unclosed files.
* Adds support for inspecting how many files/mmaps Sparkey currently
  has open.
* Refactor the memory-unmapper to function on more modern JDKs.