### PR TITLE
Add Zstd support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,12 @@
     </dependency>
 
     <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>1.4.5-5</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>27.0.1-jre</version>

--- a/src/main/java/com/spotify/sparkey/CompressedOutputStream.java
+++ b/src/main/java/com/spotify/sparkey/CompressedOutputStream.java
@@ -29,7 +29,7 @@ final class CompressedOutputStream extends OutputStream {
   private final byte[] compressedBuffer;
   private final FileDescriptor fileDescriptor;
   private int pending;
-  private SnappyWriter listener = SnappyWriter.DUMMY;
+  private CompressedWriter listener = CompressedWriter.DUMMY;
 
   CompressedOutputStream(CompressorType compressor, int maxBlockSize, OutputStream output, FileDescriptor fileDescriptor) throws IOException {
     this.compressor = compressor;
@@ -111,8 +111,8 @@ final class CompressedOutputStream extends OutputStream {
     return maxBlockSize - pending;
   }
 
-  void setListener(SnappyWriter snappyWriter) {
-    listener = snappyWriter;
+  void setListener(CompressedWriter compressedWriter) {
+    listener = compressedWriter;
   }
 
   int getMaxBlockSize() {

--- a/src/main/java/com/spotify/sparkey/CompressedOutputStream.java
+++ b/src/main/java/com/spotify/sparkey/CompressedOutputStream.java
@@ -15,14 +15,13 @@
  */
 package com.spotify.sparkey;
 
-import org.xerial.snappy.Snappy;
-
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.SyncFailedException;
 
-final class SnappyOutputStream extends OutputStream {
+final class CompressedOutputStream extends OutputStream {
+  private final CompressorType compressor;
   private final int maxBlockSize;
   private final OutputStream output;
 
@@ -32,7 +31,8 @@ final class SnappyOutputStream extends OutputStream {
   private int pending;
   private SnappyWriter listener = SnappyWriter.DUMMY;
 
-  SnappyOutputStream(int maxBlockSize, OutputStream output, FileDescriptor fileDescriptor) throws IOException {
+  CompressedOutputStream(CompressorType compressor, int maxBlockSize, OutputStream output, FileDescriptor fileDescriptor) throws IOException {
+    this.compressor = compressor;
     this.fileDescriptor = fileDescriptor;
     if (maxBlockSize < 10) {
       throw new IOException("Too small block size - won't be able to fit keylen + valuelen in a single block");
@@ -40,7 +40,7 @@ final class SnappyOutputStream extends OutputStream {
     this.maxBlockSize = maxBlockSize;
     this.output = output;
     uncompressedBuffer = new byte[maxBlockSize];
-    compressedBuffer = new byte[Snappy.maxCompressedLength(maxBlockSize)];
+    compressedBuffer = new byte[compressor.maxCompressedLength(maxBlockSize)];
   }
 
   @Override
@@ -49,7 +49,7 @@ final class SnappyOutputStream extends OutputStream {
       return;
     }
 
-    int compressedSize = Snappy.compress(uncompressedBuffer, 0, pending, compressedBuffer, 0);
+    int compressedSize = compressor.compress(uncompressedBuffer, pending, compressedBuffer);
     Util.writeUnsignedVLQ(compressedSize, output);
     output.write(compressedBuffer, 0, compressedSize);
     output.flush();

--- a/src/main/java/com/spotify/sparkey/CompressedWriter.java
+++ b/src/main/java/com/spotify/sparkey/CompressedWriter.java
@@ -1,0 +1,121 @@
+package com.spotify.sparkey;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+class CompressedWriter implements BlockOutput {
+  public static final CompressedWriter DUMMY = new CompressedWriter();
+
+  private final byte[] buf = new byte[1024*1024];
+  private final CompressedOutputStream compressedOutputStream;
+
+  private int currentNumEntries;
+  private int maxEntriesPerBlock;
+  private boolean flushed;
+  private final int maxBlockSize;
+
+  // Only used to initialize dummy
+  private CompressedWriter() {
+    compressedOutputStream = null;
+    maxBlockSize = 0;
+  }
+
+  public CompressedWriter(CompressedOutputStream compressedOutputStream, int maxEntriesPerBlock) {
+    this.compressedOutputStream = compressedOutputStream;
+    this.maxEntriesPerBlock = maxEntriesPerBlock;
+    compressedOutputStream.setListener(this);
+    maxBlockSize = this.compressedOutputStream.getMaxBlockSize();
+  }
+
+  public void afterFlush() {
+    maxEntriesPerBlock = Math.max(currentNumEntries, maxEntriesPerBlock);
+    currentNumEntries = 0;
+    flushed = true;
+  }
+
+  @Override
+  public void flush(boolean fsync) throws IOException {
+    compressedOutputStream.flush();
+    if (fsync) {
+      compressedOutputStream.fsync();
+    }
+  }
+
+  @Override
+  public void put(byte[] key, int keyLen, byte[] value, int valueLen) throws IOException {
+    int keySize = Util.unsignedVLQSize(keyLen + 1) + Util.unsignedVLQSize(valueLen);
+    int totalSize = keySize + keyLen + valueLen;
+
+    smartFlush(keySize, totalSize);
+    flushed = false;
+    currentNumEntries++;
+
+    Util.writeUnsignedVLQ(keyLen + 1, compressedOutputStream);
+    Util.writeUnsignedVLQ(valueLen, compressedOutputStream);
+    compressedOutputStream.write(key, 0, keyLen);
+    compressedOutputStream.write(value, 0, valueLen);
+
+
+    // Make sure that the beginning of each block is the start of a key/value pair
+    if (flushed && compressedOutputStream.getPending() > 0) {
+      compressedOutputStream.flush();
+    }
+  }
+
+  @Override
+  public void put(byte[] key, int keyLen, InputStream value, long valueLen) throws IOException {
+    int keySize = Util.unsignedVLQSize(keyLen + 1) + Util.unsignedVLQSize(valueLen);
+    long totalSize = keySize + keyLen + valueLen;
+
+    smartFlush(keySize, totalSize);
+    flushed = false;
+    currentNumEntries++;
+
+    Util.writeUnsignedVLQ(keyLen + 1, compressedOutputStream);
+    Util.writeUnsignedVLQ(valueLen, compressedOutputStream);
+    compressedOutputStream.write(key, 0, keyLen);
+    Util.copy(valueLen, value, compressedOutputStream, buf);
+
+    // Make sure that the beginning of each block is the start of a key/value pair
+    if (flushed && compressedOutputStream.getPending() > 0) {
+      compressedOutputStream.flush();
+    }
+  }
+
+  private void smartFlush(int keySize, long totalSize) throws IOException {
+    int remaining = compressedOutputStream.remaining();
+    if (remaining < keySize) {
+      flush(false);
+    } else if (remaining < totalSize && totalSize < maxBlockSize - remaining) {
+      flush(false);
+    }
+  }
+
+  @Override
+  public void delete(byte[] key, int keyLen) throws IOException {
+    int keySize = 1 + Util.unsignedVLQSize(keyLen + 1);
+    smartFlush(keySize, keySize + keyLen);
+
+    flushed = false;
+    currentNumEntries++;
+
+    compressedOutputStream.write(0);
+    Util.writeUnsignedVLQ(keyLen, compressedOutputStream);
+    compressedOutputStream.write(key, 0, keyLen);
+
+    // Make sure that the beginning of each block is the start of a key/value pair
+    if (flushed && compressedOutputStream.getPending() > 0) {
+      compressedOutputStream.flush();
+    }
+  }
+
+  @Override
+  public void close(boolean fsync) throws IOException {
+    flush(fsync);
+    compressedOutputStream.close();
+  }
+
+  public int getMaxEntriesPerBlock() {
+    return maxEntriesPerBlock;
+  }
+}

--- a/src/main/java/com/spotify/sparkey/CompressionType.java
+++ b/src/main/java/com/spotify/sparkey/CompressionType.java
@@ -52,7 +52,7 @@ public enum CompressionType {
 
     @Override
     BlockOutput createBlockOutput(FileDescriptor fd, OutputStream outputStream, int maxBlockSize, int maxEntriesPerBlock) throws IOException {
-      return new SnappyWriter(new SnappyOutputStream(maxBlockSize, outputStream, fd), maxEntriesPerBlock);
+      return new SnappyWriter(new CompressedOutputStream(CompressorType.SNAPPY, maxBlockSize, outputStream, fd), maxEntriesPerBlock);
     }
   },;
 

--- a/src/main/java/com/spotify/sparkey/CompressionType.java
+++ b/src/main/java/com/spotify/sparkey/CompressionType.java
@@ -42,12 +42,12 @@ public enum CompressionType {
   SNAPPY {
     @Override
     BlockPositionedInputStream createBlockInput(InputStream inputStream, int maxBlockSize, long start) {
-      return new SnappyReader(inputStream, maxBlockSize, start);
+      return new CompressedReader(CompressorType.SNAPPY, inputStream, maxBlockSize, start);
     }
 
     @Override
     BlockRandomInput createRandomAccessData(ReadOnlyMemMap data, int maxBlockSize) {
-      return new SnappyRandomReader(new UncompressedBlockRandomInput(data), maxBlockSize);
+      return new CompressedRandomReader(CompressorType.SNAPPY, new UncompressedBlockRandomInput(data), maxBlockSize);
     }
 
     @Override

--- a/src/main/java/com/spotify/sparkey/CompressionType.java
+++ b/src/main/java/com/spotify/sparkey/CompressionType.java
@@ -52,7 +52,7 @@ public enum CompressionType {
 
     @Override
     BlockOutput createBlockOutput(FileDescriptor fd, OutputStream outputStream, int maxBlockSize, int maxEntriesPerBlock) throws IOException {
-      return new SnappyWriter(new CompressedOutputStream(CompressorType.SNAPPY, maxBlockSize, outputStream, fd), maxEntriesPerBlock);
+      return new CompressedWriter(new CompressedOutputStream(CompressorType.SNAPPY, maxBlockSize, outputStream, fd), maxEntriesPerBlock);
     }
   },;
 

--- a/src/main/java/com/spotify/sparkey/CompressionType.java
+++ b/src/main/java/com/spotify/sparkey/CompressionType.java
@@ -17,7 +17,8 @@ package com.spotify.sparkey;
 
 public enum CompressionType {
   NONE(new CompressionTypeBackendUncompressed()),
-  SNAPPY(new CompressionTypeBackendCompressed(CompressorType.SNAPPY)),;
+  SNAPPY(new CompressionTypeBackendCompressed(CompressorType.SNAPPY)),
+  ZSTD(new CompressionTypeBackendCompressed(CompressorType.ZSTD)),;
 
   private final CompressionTypeBackend backend;
 

--- a/src/main/java/com/spotify/sparkey/CompressionTypeBackend.java
+++ b/src/main/java/com/spotify/sparkey/CompressionTypeBackend.java
@@ -62,7 +62,7 @@ class CompressionTypeBackendCompressed implements CompressionTypeBackend {
 
     @Override
     public BlockOutput createBlockOutput(FileDescriptor fd, OutputStream outputStream, int maxBlockSize, int maxEntriesPerBlock) throws IOException {
-        return new CompressedWriter(new CompressedOutputStream(CompressorType.SNAPPY, maxBlockSize, outputStream, fd), maxEntriesPerBlock);
+        return new CompressedWriter(new CompressedOutputStream(compressor, maxBlockSize, outputStream, fd), maxEntriesPerBlock);
     }
 }
 

--- a/src/main/java/com/spotify/sparkey/CompressionTypeBackend.java
+++ b/src/main/java/com/spotify/sparkey/CompressionTypeBackend.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2013 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.sparkey;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+interface CompressionTypeBackend {
+    BlockOutput createBlockOutput(FileDescriptor fd, OutputStream outputStream, int maxBlockSize, int maxEntriesPerBlock) throws IOException;
+    BlockPositionedInputStream createBlockInput(InputStream inputStream, int maxBlockSize, long start);
+    BlockRandomInput createRandomAccessData(ReadOnlyMemMap data, int maxBlockSize);
+}
+
+class CompressionTypeBackendUncompressed implements CompressionTypeBackend {
+    @Override
+    public BlockPositionedInputStream createBlockInput(InputStream inputStream, int maxBlockSize, long start) {
+        return new UncompressedBlockPositionedInputStream(inputStream, start);
+    }
+
+    @Override
+    public BlockRandomInput createRandomAccessData(ReadOnlyMemMap data, int maxBlockSize) {
+        return new UncompressedBlockRandomInput(data);
+    }
+
+    @Override
+    public BlockOutput createBlockOutput(FileDescriptor fd, OutputStream outputStream, int maxBlockSize, int maxEntriesPerBlock) throws IOException {
+        return new UncompressedBlockOutput(outputStream, fd);
+    }
+}
+
+class CompressionTypeBackendCompressed implements CompressionTypeBackend {
+    private final CompressorType compressor;
+
+    public CompressionTypeBackendCompressed(CompressorType compressor) {
+        this.compressor = compressor;
+    }
+
+    @Override
+    public BlockPositionedInputStream createBlockInput(InputStream inputStream, int maxBlockSize, long start) {
+        return new CompressedReader(compressor, inputStream, maxBlockSize, start);
+    }
+
+    @Override
+    public BlockRandomInput createRandomAccessData(ReadOnlyMemMap data, int maxBlockSize) {
+        return new CompressedRandomReader(compressor, new UncompressedBlockRandomInput(data), maxBlockSize);
+    }
+
+    @Override
+    public BlockOutput createBlockOutput(FileDescriptor fd, OutputStream outputStream, int maxBlockSize, int maxEntriesPerBlock) throws IOException {
+        return new CompressedWriter(new CompressedOutputStream(CompressorType.SNAPPY, maxBlockSize, outputStream, fd), maxEntriesPerBlock);
+    }
+}
+

--- a/src/main/java/com/spotify/sparkey/CompressorType.java
+++ b/src/main/java/com/spotify/sparkey/CompressorType.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2013 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.sparkey;
+
+import java.io.IOException;
+
+import com.github.luben.zstd.Zstd;
+
+import org.xerial.snappy.Snappy;
+
+public enum CompressorType {
+  SNAPPY {
+    @Override
+    int maxCompressedLength(int blockSize) {
+      return Snappy.maxCompressedLength(blockSize);
+    }
+
+    @Override
+    int uncompress(byte[] compressed, int compressedSize, byte[] uncompressed) throws IOException {
+      return Snappy.uncompress(compressed, 0, compressedSize, uncompressed, 0);
+    }
+  
+    @Override
+    int compress(byte[] uncompressed, int uncompressedSize, byte[] compressed) throws IOException {
+      return Snappy.compress(uncompressed, 0, uncompressedSize, compressed, 0);
+    }
+  },
+
+  ZSTD {
+    @Override
+    int maxCompressedLength(int blockSize) {
+      return (int)Zstd.compressBound(blockSize);
+    }
+
+    @Override
+    int uncompress(byte[] compressed, int compressedSize, byte[] uncompressed) throws IOException {
+      return (int)Zstd.decompressByteArray(uncompressed, 0, uncompressed.length, compressed, 0, compressedSize);
+    }
+  
+    @Override
+    int compress(byte[] uncompressed, int uncompressedSize, byte[] compressed) throws IOException {
+      return (int)Zstd.compressByteArray(compressed, 0, compressed.length, uncompressed, 0, uncompressedSize, 3);
+    }
+  },;
+
+  abstract int maxCompressedLength(int blockSize);
+
+  abstract int uncompress(byte[] compressed, int compressedSize, byte[] uncompressed) throws IOException;
+
+  abstract int compress(byte[] uncompressed, int uncompressedSize, byte[] compressed) throws IOException;
+}

--- a/src/main/java/com/spotify/sparkey/CompressorType.java
+++ b/src/main/java/com/spotify/sparkey/CompressorType.java
@@ -21,7 +21,7 @@ import com.github.luben.zstd.Zstd;
 
 import org.xerial.snappy.Snappy;
 
-public enum CompressorType {
+enum CompressorType {
   SNAPPY {
     @Override
     int maxCompressedLength(int blockSize) {

--- a/src/main/java/com/spotify/sparkey/IndexHash.java
+++ b/src/main/java/com/spotify/sparkey/IndexHash.java
@@ -81,7 +81,7 @@ final class IndexHash {
       int maxBlockSize = 0;
       indexData = new ReadOnlyMemMap(indexFile);
       maxBlockSize = logHeader.getCompressionBlockSize();
-      logData = logHeader.getCompressionType().createRandomAccessData(new ReadOnlyMemMap(logFile),
+      logData = logHeader.getCompressionTypeBackend().createRandomAccessData(new ReadOnlyMemMap(logFile),
               maxBlockSize);
 
       indexHash = new IndexHash(indexFile, logFile, header, logHeader, indexData, maxBlockSize, logData);
@@ -245,7 +245,7 @@ final class IndexHash {
 
   private static void fillFromLog(ReadWriteData indexData, File logFile, IndexHeader header, long start, long end, LogHeader logHeader) throws IOException {
     SparkeyLogIterator iterator = new SparkeyLogIterator(logFile, start, end);
-    BlockRandomInput logData = logHeader.getCompressionType().createRandomAccessData(new ReadOnlyMemMap(logFile), logHeader.getCompressionBlockSize());
+    BlockRandomInput logData = logHeader.getCompressionTypeBackend().createRandomAccessData(new ReadOnlyMemMap(logFile), logHeader.getCompressionBlockSize());
 
     HashType hashData = header.getHashType();
     AddressSize addressData = header.getAddressData();
@@ -302,7 +302,7 @@ final class IndexHash {
     final long hashCapacity = header.getHashCapacity();
 
     final BlockRandomInput logData =
-        logHeader.getCompressionType().createRandomAccessData(new ReadOnlyMemMap(logFile), logHeader.getCompressionBlockSize());
+        logHeader.getCompressionTypeBackend().createRandomAccessData(new ReadOnlyMemMap(logFile), logHeader.getCompressionBlockSize());
 
     try {
       final Iterator<SortHelper.Entry> iterator2 = SortHelper.sort(

--- a/src/main/java/com/spotify/sparkey/LogHeader.java
+++ b/src/main/java/com/spotify/sparkey/LogHeader.java
@@ -142,6 +142,10 @@ public final class LogHeader extends CommonHeader {
     return compressionType;
   }
 
+  CompressionTypeBackend getCompressionTypeBackend() {
+    return getCompressionType().getBackend();
+  }
+
   public long getDataEnd() {
     return dataEnd;
   }

--- a/src/main/java/com/spotify/sparkey/LogWriter.java
+++ b/src/main/java/com/spotify/sparkey/LogWriter.java
@@ -50,7 +50,7 @@ final class LogWriter {
     Sparkey.incrOpenFiles();
     FileDescriptor fd = fileOutputStream.getFD();
     OutputStream stream = new BufferedOutputStream(fileOutputStream, 1024 * 1024);
-    return header.getCompressionType().createBlockOutput(fd, stream, header.getCompressionBlockSize(),
+    return header.getCompressionTypeBackend().createBlockOutput(fd, stream, header.getCompressionBlockSize(),
             header.getMaxEntriesPerBlock());
   }
 

--- a/src/main/java/com/spotify/sparkey/SnappyWriter.java
+++ b/src/main/java/com/spotify/sparkey/SnappyWriter.java
@@ -1,121 +1,23 @@
+/*
+ * Copyright (c) 2011-2013 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.spotify.sparkey;
 
-import java.io.IOException;
-import java.io.InputStream;
-
-public class SnappyWriter implements BlockOutput {
-  public static final SnappyWriter DUMMY = new SnappyWriter();
-
-  private final byte[] buf = new byte[1024*1024];
-  private final CompressedOutputStream compressedOutputStream;
-
-  private int currentNumEntries;
-  private int maxEntriesPerBlock;
-  private boolean flushed;
-  private final int maxBlockSize;
-
-  // Only used to initialize dummy
-  private SnappyWriter() {
-    compressedOutputStream = null;
-    maxBlockSize = 0;
-  }
-
-  public SnappyWriter(CompressedOutputStream compressedOutputStream, int maxEntriesPerBlock) {
-    this.compressedOutputStream = compressedOutputStream;
-    this.maxEntriesPerBlock = maxEntriesPerBlock;
-    compressedOutputStream.setListener(this);
-    maxBlockSize = this.compressedOutputStream.getMaxBlockSize();
-  }
-
-  public void afterFlush() {
-    maxEntriesPerBlock = Math.max(currentNumEntries, maxEntriesPerBlock);
-    currentNumEntries = 0;
-    flushed = true;
-  }
-
-  @Override
-  public void flush(boolean fsync) throws IOException {
-    compressedOutputStream.flush();
-    if (fsync) {
-      compressedOutputStream.fsync();
+@Deprecated
+public class SnappyWriter extends CompressedWriter {
+    public SnappyWriter(CompressedOutputStream compressedOutputStream, int maxEntriesPerBlock) {
+        super(compressedOutputStream, maxEntriesPerBlock);
     }
-  }
-
-  @Override
-  public void put(byte[] key, int keyLen, byte[] value, int valueLen) throws IOException {
-    int keySize = Util.unsignedVLQSize(keyLen + 1) + Util.unsignedVLQSize(valueLen);
-    int totalSize = keySize + keyLen + valueLen;
-
-    smartFlush(keySize, totalSize);
-    flushed = false;
-    currentNumEntries++;
-
-    Util.writeUnsignedVLQ(keyLen + 1, compressedOutputStream);
-    Util.writeUnsignedVLQ(valueLen, compressedOutputStream);
-    compressedOutputStream.write(key, 0, keyLen);
-    compressedOutputStream.write(value, 0, valueLen);
-
-
-    // Make sure that the beginning of each block is the start of a key/value pair
-    if (flushed && compressedOutputStream.getPending() > 0) {
-      compressedOutputStream.flush();
-    }
-  }
-
-  @Override
-  public void put(byte[] key, int keyLen, InputStream value, long valueLen) throws IOException {
-    int keySize = Util.unsignedVLQSize(keyLen + 1) + Util.unsignedVLQSize(valueLen);
-    long totalSize = keySize + keyLen + valueLen;
-
-    smartFlush(keySize, totalSize);
-    flushed = false;
-    currentNumEntries++;
-
-    Util.writeUnsignedVLQ(keyLen + 1, compressedOutputStream);
-    Util.writeUnsignedVLQ(valueLen, compressedOutputStream);
-    compressedOutputStream.write(key, 0, keyLen);
-    Util.copy(valueLen, value, compressedOutputStream, buf);
-
-    // Make sure that the beginning of each block is the start of a key/value pair
-    if (flushed && compressedOutputStream.getPending() > 0) {
-      compressedOutputStream.flush();
-    }
-  }
-
-  private void smartFlush(int keySize, long totalSize) throws IOException {
-    int remaining = compressedOutputStream.remaining();
-    if (remaining < keySize) {
-      flush(false);
-    } else if (remaining < totalSize && totalSize < maxBlockSize - remaining) {
-      flush(false);
-    }
-  }
-
-  @Override
-  public void delete(byte[] key, int keyLen) throws IOException {
-    int keySize = 1 + Util.unsignedVLQSize(keyLen + 1);
-    smartFlush(keySize, keySize + keyLen);
-
-    flushed = false;
-    currentNumEntries++;
-
-    compressedOutputStream.write(0);
-    Util.writeUnsignedVLQ(keyLen, compressedOutputStream);
-    compressedOutputStream.write(key, 0, keyLen);
-
-    // Make sure that the beginning of each block is the start of a key/value pair
-    if (flushed && compressedOutputStream.getPending() > 0) {
-      compressedOutputStream.flush();
-    }
-  }
-
-  @Override
-  public void close(boolean fsync) throws IOException {
-    flush(fsync);
-    compressedOutputStream.close();
-  }
-
-  public int getMaxEntriesPerBlock() {
-    return maxEntriesPerBlock;
-  }
 }

--- a/src/main/java/com/spotify/sparkey/SparkeyLogIterator.java
+++ b/src/main/java/com/spotify/sparkey/SparkeyLogIterator.java
@@ -71,7 +71,7 @@ public final class SparkeyLogIterator implements Iterable<SparkeyReader.Entry> {
         Sparkey.incrOpenFiles();
         stream2.skip(start);
 
-        stream = header.getCompressionType().createBlockInput(stream2, header.getCompressionBlockSize(), start);
+        stream = header.getCompressionTypeBackend().createBlockInput(stream2, header.getCompressionBlockSize(), start);
       }
 
       return new Iterator<SparkeyReader.Entry>() {

--- a/src/test/java/com/spotify/sparkey/BytesWrittenTest.java
+++ b/src/test/java/com/spotify/sparkey/BytesWrittenTest.java
@@ -35,6 +35,11 @@ public class BytesWrittenTest extends OpenMapsAsserter {
     test(CompressionType.SNAPPY);
   }
 
+  @Test
+  public void testZstd() throws Exception {
+    test(CompressionType.ZSTD);
+  }
+
   private void test(CompressionType compressionType) throws IOException {
     SparkeyWriter writer = Sparkey.createNew(file, compressionType, 20);
     for (int i = 0; i < 13; i++) {

--- a/src/test/java/com/spotify/sparkey/CompressedOutputStreamTest.java
+++ b/src/test/java/com/spotify/sparkey/CompressedOutputStreamTest.java
@@ -5,9 +5,9 @@ import org.junit.Test;
 import java.io.*;
 
 /**
- * Tests SnappyOutputStream
+ * Tests CompressedOutputStream
  */
-public class SnappyOutputStreamTest {
+public class CompressedOutputStreamTest {
     @Test
     public void testLargeWrite() throws IOException {
         File testFile = File.createTempFile("sparkey-test", "");
@@ -15,7 +15,7 @@ public class SnappyOutputStreamTest {
         FileOutputStream fos = new FileOutputStream(testFile);
 
         byte[] buf = new byte[1000 * 1000];
-        SnappyOutputStream os = new SnappyOutputStream(10, fos, fos.getFD());
+        CompressedOutputStream os = new CompressedOutputStream(CompressorType.SNAPPY, 10, fos, fos.getFD());
         os.write(buf);
 
         testFile.delete();

--- a/src/test/java/com/spotify/sparkey/CompressedOutputStreamTest.java
+++ b/src/test/java/com/spotify/sparkey/CompressedOutputStreamTest.java
@@ -10,14 +10,16 @@ import java.io.*;
 public class CompressedOutputStreamTest {
     @Test
     public void testLargeWrite() throws IOException {
-        File testFile = File.createTempFile("sparkey-test", "");
-        testFile.deleteOnExit();
-        FileOutputStream fos = new FileOutputStream(testFile);
+        for (CompressorType compressor : CompressorType.values()) {
+            File testFile = File.createTempFile("sparkey-test", "");
+            testFile.deleteOnExit();
+            FileOutputStream fos = new FileOutputStream(testFile);
 
-        byte[] buf = new byte[1000 * 1000];
-        CompressedOutputStream os = new CompressedOutputStream(CompressorType.SNAPPY, 10, fos, fos.getFD());
-        os.write(buf);
+            byte[] buf = new byte[1000 * 1000];
+            CompressedOutputStream os = new CompressedOutputStream(compressor, 10, fos, fos.getFD());
+            os.write(buf);
 
-        testFile.delete();
+            testFile.delete();
+        }
     }
 }

--- a/src/test/java/com/spotify/sparkey/CompressedReaderTest.java
+++ b/src/test/java/com/spotify/sparkey/CompressedReaderTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests SnappyReader
  */
-public class SnappyReaderTest {
+public class CompressedReaderTest {
     // A stream that reads the same array repeatedly, forever.
     private class RepeatingInputStream extends InputStream {
         private byte[] buffer;
@@ -45,7 +45,7 @@ public class SnappyReaderTest {
         }
     }
 
-    private SnappyReader reader() throws IOException {
+    private CompressedReader reader() throws IOException {
         byte[] uncompressed = new byte[10];
         for (int i = 0; i < uncompressed.length; ++i) {
             uncompressed[i] = (byte)i;
@@ -57,7 +57,7 @@ public class SnappyReaderTest {
         bytes.write(compressed);
 
         InputStream buf = new RepeatingInputStream(bytes.toByteArray());
-        return new SnappyReader(buf, uncompressed.length, 0);
+        return new CompressedReader(CompressorType.SNAPPY, buf, uncompressed.length, 0);
     }
 
     @Test

--- a/src/test/java/com/spotify/sparkey/system/AppendBenchmark.java
+++ b/src/test/java/com/spotify/sparkey/system/AppendBenchmark.java
@@ -56,7 +56,7 @@ public class AppendBenchmark {
     logFile.delete();
   }
 
-  @Param({"NONE", "SNAPPY"})
+  @Param({"NONE", "SNAPPY", "ZSTD"})
   public String type;
 
   @Benchmark

--- a/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
+++ b/src/test/java/com/spotify/sparkey/system/CorrectnessTest.java
@@ -55,6 +55,9 @@ public class CorrectnessTest extends BaseSystemTest {
         testHelper(size, CompressionType.SNAPPY, 64, hashType);
         testHelper(size, CompressionType.SNAPPY, 1024, hashType);
         testHelper(size, CompressionType.SNAPPY, 4096, hashType);
+        testHelper(size, CompressionType.ZSTD, 64, hashType);
+        testHelper(size, CompressionType.ZSTD, 1024, hashType);
+        testHelper(size, CompressionType.ZSTD, 4096, hashType);
       }
     }
   }
@@ -180,6 +183,9 @@ public class CorrectnessTest extends BaseSystemTest {
         testHelperWithDeletes(size, CompressionType.SNAPPY, 64, hashType);
         testHelperWithDeletes(size, CompressionType.SNAPPY, 1024, hashType);
         testHelperWithDeletes(size, CompressionType.SNAPPY, 4096, hashType);
+        testHelperWithDeletes(size, CompressionType.ZSTD, 64, hashType);
+        testHelperWithDeletes(size, CompressionType.ZSTD, 1024, hashType);
+        testHelperWithDeletes(size, CompressionType.ZSTD, 4096, hashType);
       }
     }
   }

--- a/src/test/java/com/spotify/sparkey/system/FsyncBenchmark.java
+++ b/src/test/java/com/spotify/sparkey/system/FsyncBenchmark.java
@@ -47,7 +47,7 @@ public class FsyncBenchmark {
   private File logFile;
   private SparkeyWriter writer;
 
-  @Param({"NONE", "SNAPPY"})
+  @Param({"NONE", "SNAPPY", "ZSTD"})
   public String type;
 
   @Param({"true", "false"})

--- a/src/test/java/com/spotify/sparkey/system/LookupBenchmark.java
+++ b/src/test/java/com/spotify/sparkey/system/LookupBenchmark.java
@@ -68,7 +68,7 @@ public class LookupBenchmark {
   @Param({"1000", "10000", "100000", "1000000", "10000000", "100000000"})
   public int numElements;
 
-  @Param({"NONE", "SNAPPY"})
+  @Param({"NONE", "SNAPPY", "ZSTD"})
   public String type;
 
   @Benchmark


### PR DESCRIPTION
Zstd support for Java, to go with the C support proposed here: https://github.com/spotify/sparkey/pull/42

I did some very basic interop tests, and it seems ok.