### PR TITLE
expose loaded/total bytes

### DIFF
--- a/src/main/java/com/spotify/sparkey/BlockRandomInput.java
+++ b/src/main/java/com/spotify/sparkey/BlockRandomInput.java
@@ -32,4 +32,6 @@ interface BlockRandomInput {
   BlockRandomInput duplicate();
 
   void closeDuplicate();
+
+  long getLoadedBytes();
 }

--- a/src/main/java/com/spotify/sparkey/CompressedRandomReader.java
+++ b/src/main/java/com/spotify/sparkey/CompressedRandomReader.java
@@ -119,4 +119,8 @@ final class CompressedRandomReader implements BlockRandomInput {
     data.closeDuplicate();
   }
 
+  @Override
+  public long getLoadedBytes() {
+    return data.getLoadedBytes();
+  }
 }

--- a/src/main/java/com/spotify/sparkey/IndexHash.java
+++ b/src/main/java/com/spotify/sparkey/IndexHash.java
@@ -669,6 +669,10 @@ final class IndexHash {
     logData.closeDuplicate();
   }
 
+  long getLoadedBytes() {
+    return indexData.getLoadedBytes() + logData.getLoadedBytes();
+  }
+
   private class IndexHashEntry implements SparkeyReader.Entry {
     private int keyLen;
     private long valueLen;

--- a/src/main/java/com/spotify/sparkey/ReadOnlyMemMap.java
+++ b/src/main/java/com/spotify/sparkey/ReadOnlyMemMap.java
@@ -228,6 +228,16 @@ final class ReadOnlyMemMap implements RandomAccessData {
     }
   }
 
+  public long getLoadedBytes() {
+    long bytes = 0;
+    for (MappedByteBuffer chunk : chunks) {
+      if (chunk.isLoaded()) {
+        bytes += chunk.capacity();
+      }
+    }
+    return bytes;
+  }
+
   private MappedByteBuffer[] getChunks() throws SparkeyReaderClosedException {
     MappedByteBuffer[] localChunks = chunks;
     if (localChunks == null) {

--- a/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/SingleThreadedSparkeyReader.java
@@ -141,6 +141,16 @@ final class SingleThreadedSparkeyReader implements SparkeyReader {
     };
   }
 
+  @Override
+  public long getLoadedBytes() {
+    return index.getLoadedBytes();
+  }
+
+  @Override
+  public long getTotalBytes() {
+    return indexFile.length() + logFile.length();
+  }
+
   private static boolean isValid(int keyLen, byte[] keyBuf, long position, int entryIndex, IndexHash indexHash) throws IOException {
     return indexHash.isAt(keyLen, keyBuf, position, entryIndex);
   }

--- a/src/main/java/com/spotify/sparkey/SparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/SparkeyReader.java
@@ -82,6 +82,16 @@ public interface SparkeyReader extends Iterable<SparkeyReader.Entry>, Closeable 
     Type getType();
   }
 
+  /**
+   * Get the number of index and log file bytes loaded in memory.
+   */
+  long getLoadedBytes();
+
+  /**
+   * Get the total number of index and log file bytes.
+   */
+  long getTotalBytes();
+
   enum Type {
     PUT, DELETE
   }

--- a/src/main/java/com/spotify/sparkey/UncompressedBlockRandomInput.java
+++ b/src/main/java/com/spotify/sparkey/UncompressedBlockRandomInput.java
@@ -58,4 +58,9 @@ class UncompressedBlockRandomInput implements BlockRandomInput {
   public void closeDuplicate() {
     data.closeDuplicate();
   }
+
+  @Override
+  public long getLoadedBytes() {
+    return data.getLoadedBytes();
+  }
 }

--- a/src/main/java/com/spotify/sparkey/extra/AbstractDelegatingSparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/extra/AbstractDelegatingSparkeyReader.java
@@ -72,4 +72,13 @@ public abstract class AbstractDelegatingSparkeyReader implements SparkeyReader {
     return getDelegateReader().iterator();
   }
 
+  @Override
+  public long getLoadedBytes() {
+    return getDelegateReader().getLoadedBytes();
+  }
+
+  @Override
+  public long getTotalBytes() {
+    return getDelegateReader().getTotalBytes();
+  }
 }

--- a/src/test/java/com/spotify/sparkey/UtilTest.java
+++ b/src/test/java/com/spotify/sparkey/UtilTest.java
@@ -172,6 +172,11 @@ public class UtilTest {
     public void closeDuplicate() {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public long getLoadedBytes() {
+      return data.length;
+    }
   }
 
   @Test

--- a/src/test/java/com/spotify/sparkey/extra/DelegatingSparkeyReaderTest.java
+++ b/src/test/java/com/spotify/sparkey/extra/DelegatingSparkeyReaderTest.java
@@ -46,6 +46,12 @@ public class DelegatingSparkeyReaderTest {
     reader.iterator();
     verify(delegate).iterator();
 
+    reader.getLoadedBytes();
+    verify(delegate).getLoadedBytes();
+
+    reader.getTotalBytes();
+    verify(delegate).getTotalBytes();
+
     reader.close();
     verify(delegate).close();
   }

--- a/src/test/java/com/spotify/sparkey/system/LargeFilesTest.java
+++ b/src/test/java/com/spotify/sparkey/system/LargeFilesTest.java
@@ -42,10 +42,13 @@ public class LargeFilesTest extends BaseSystemTest {
 
     assertTrue(logFile.length() > 2000 * 5 * 1024);
     SparkeyReader reader = Sparkey.open(indexFile);
+    assertEquals(indexFile.length() + logFile.length(), reader.getTotalBytes());
+    assertTrue(reader.getLoadedBytes() <= reader.getTotalBytes());
     for (int i = 0; i < 2000; i += 100) {
       assertEquals(expectedValue, reader.getAsString("key_" + i));
     }
     assertEquals(null, reader.getAsString("key_" + 2000));
+    assertEquals(reader.getTotalBytes(), reader.getLoadedBytes());
     reader.close();
   }
 
@@ -75,11 +78,13 @@ public class LargeFilesTest extends BaseSystemTest {
 
     assertTrue(indexFile.length() > size * 8L);
     SparkeyReader reader = Sparkey.open(indexFile);
+    assertTrue(reader.getLoadedBytes() <= reader.getTotalBytes());
     for (int i = 0; i < 1000; i++) {
       long key = i * size / 1000L;
       assertEquals("" + (key % 13), reader.getAsString("key_" + key));
     }
     assertEquals(null, reader.getAsString("key_" + size));
+    assertEquals(reader.getTotalBytes(), reader.getLoadedBytes());
     reader.close();
   }
 }


### PR DESCRIPTION
Verified with a simple job with 50M UUID KV pairs (~3.7GB log & 1GB index). After writing & clearing cache with `sync; echo 3 | sudo tee -a /proc/sys/vm/drop_caches`, iterating the file shows loaded bytes incrementing in ~1GB chunks (probably a setting in Linux kernel).