### PR TITLE
Add ThreadLocalWithFallback

### DIFF
--- a/src/main/java/com/spotify/sparkey/extra/PersistentThreadLocal.java
+++ b/src/main/java/com/spotify/sparkey/extra/PersistentThreadLocal.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.sparkey.extra;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Since Java 17, using ThreadLocal may not behave as expected
+ * when being called from ForkJoinPool.commonPool().
+ * The common pool will clear all values for ThreadLocal after finishing a task,
+ * so it can not be used for retaining expensive objects on the same thread across
+ * multiple tasks.
+ *
+ * This subclass will instead let values survive by using a ConcurrentHashMap
+ * based on Thread Id which is stable as long as the thread lives. This map is also cleaned up by
+ * detecting thread death using a WeakReference.
+ *
+ * This implementation differs from the regular ThreadLocal in that it does not allow null values from the supplier.
+ */
+class PersistentThreadLocal<T> extends ThreadLocal<T> {
+  private final Map<Long, T> fallback = new ConcurrentHashMap<>();
+  private final Supplier<? extends T> supplier;
+  private final Consumer<? super T> closer;
+
+  private final ReferenceQueue<Thread> deadThreads = new ReferenceQueue<>();
+  // Used to avoid creating more weak references than necessary
+  private final Map<Long, RefWithThreadId> activeThreads = new ConcurrentHashMap<>();
+
+  private PersistentThreadLocal(Supplier<? extends T> supplier, Consumer<? super T> closer) {
+    this.supplier = supplier;
+    this.closer = closer;
+  }
+
+  @Override
+  protected T initialValue() {
+    final Thread thread = Thread.currentThread();
+    final long threadId = thread.getId();
+    final T fallbackValue = fallback.get(threadId);
+    if (fallbackValue != null) {
+      // This case is typically only reachable on Java 17+ using ForkJoinPool.commonPool()
+      return fallbackValue;
+    }
+
+    final T value = Objects.requireNonNull(supplier.get());
+    setFallback(value, thread, threadId);
+    return value;
+  }
+
+  private void setFallback(T value, Thread thread, long threadId) {
+    final T prevValue = fallback.put(threadId, value);
+    if (prevValue == null) {
+      if (!activeThreads.containsKey(threadId)) {
+        // New thread - register for death and clean up any dead threads
+        cleanupDeadThreads();
+        activeThreads.put(threadId, new RefWithThreadId(thread, threadId, deadThreads));
+      }
+    }
+  }
+
+  public static <S> PersistentThreadLocal<S> withInitial(Supplier<? extends S> supplier) {
+    return withInitial(supplier, obj -> {});
+  }
+
+  public static <S> PersistentThreadLocal<S> withInitial(Supplier<? extends S> supplier, Consumer<? super S> closer) {
+    return new PersistentThreadLocal<>(supplier, closer);
+  }
+
+  @Override
+  public void set(T value) {
+    final T nonNullValue = Objects.requireNonNull(value);
+    final Thread thread = Thread.currentThread();
+    final long threadId = thread.getId();
+    setFallback(nonNullValue, thread, threadId);
+    super.set(nonNullValue);
+  }
+
+  @Override
+  public void remove() {
+    fallback.remove(Thread.currentThread().getId());
+    super.remove();
+  }
+
+  protected void cleanupDeadThreads() {
+    RefWithThreadId ref = (RefWithThreadId) deadThreads.poll();
+    while (ref != null) {
+      final T value = fallback.remove(ref.threadId);
+      activeThreads.remove(ref.threadId);
+      if (value != null) {
+        try {
+          closer.accept(value);
+        } catch (Exception e) {
+          // Ignore exceptions, we can't crash the current thread
+        }
+      }
+      ref = (RefWithThreadId) deadThreads.poll();
+    }
+  }
+
+  int fallbackSize() {
+    return fallback.size();
+  }
+
+  private static class RefWithThreadId extends PhantomReference<Thread> {
+    private final long threadId;
+
+    public RefWithThreadId(Thread thread, long threadId, ReferenceQueue<? super Thread> q) {
+      super(thread, q);
+      this.threadId = threadId;
+    }
+  }
+}

--- a/src/main/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReader.java
+++ b/src/main/java/com/spotify/sparkey/extra/ThreadLocalSparkeyReader.java
@@ -19,13 +19,8 @@ import com.spotify.sparkey.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A thread-safe Sparkey Reader.
@@ -41,7 +36,7 @@ public class ThreadLocalSparkeyReader extends AbstractDelegatingSparkeyReader {
 
   private ThreadLocalSparkeyReader(final SparkeyReader reader) {
     this.reader = reader;
-    this.threadLocalReader = ThreadLocal.withInitial(() -> {
+    this.threadLocalReader = PersistentThreadLocal.withInitial(() -> {
       SparkeyReader r = reader.duplicate();
       readers.add(r);
       return r;

--- a/src/test/java/com/spotify/sparkey/extra/PersistentThreadLocalTest.java
+++ b/src/test/java/com/spotify/sparkey/extra/PersistentThreadLocalTest.java
@@ -1,0 +1,93 @@
+package com.spotify.sparkey.extra;
+
+import org.junit.Test;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PersistentThreadLocalTest {
+
+  private final AtomicInteger closedThreads = new AtomicInteger();
+  private final PersistentThreadLocal<Long> threadLocal =
+          PersistentThreadLocal.withInitial(() -> Thread.currentThread().getId(), threadId -> closedThreads.incrementAndGet());
+
+  @Test
+  public void testReturnsMainThreadIdWhenInMainThread() {
+    assertEquals(1, threadLocal.get().intValue());
+  }
+
+  @Test
+  public void testSet() {
+    assertEquals(Thread.currentThread().getId(), threadLocal.get().longValue());
+    threadLocal.set(123L);
+    assertEquals(123, threadLocal.get().longValue());
+    threadLocal.remove();
+    assertEquals(Thread.currentThread().getId(), threadLocal.get().longValue());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSetNull() {
+    threadLocal.set(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSuppliedNull() {
+    PersistentThreadLocal.withInitial(() -> null).get();
+  }
+
+  @Test
+  public void testForkJoinPoolCommonPool() {
+    final Thread mainThread = Thread.currentThread();
+
+    final int poolSize = ForkJoinPool.commonPool().getParallelism();
+    final AtomicInteger failures = new AtomicInteger();
+    for (int i = 0; i < 10000; i++) {
+      int finalI = i;
+      ForkJoinPool.commonPool().execute(() -> {
+        if (Thread.currentThread() == mainThread) {
+          return;
+        }
+        checkFailure(failures);
+        if (finalI < poolSize) {
+          // Make sure to keep the first poolsize workers alive for long enough to use the entire pool
+          try {
+            Thread.sleep(10);
+          } catch (InterruptedException e) {
+          }
+        }
+      });
+    }
+    assertEquals(poolSize, threadLocal.fallbackSize());
+    assertEquals(0, failures.get());
+  }
+
+  @Test
+  public void testThreadDeath() throws InterruptedException {
+    final AtomicInteger failures = new AtomicInteger();
+
+    for (int i = 0; i < 10_000; i++) {
+      Thread thread = new Thread(() -> {
+        checkFailure(failures);
+      });
+      thread.start();
+      thread.join();
+      assertEquals(Thread.State.TERMINATED, thread.getState());
+      if (threadLocal.fallbackSize() >= 10) {
+        System.gc();
+      }
+      final int fallbackSize = threadLocal.fallbackSize();
+      assertTrue("Was: " + fallbackSize, fallbackSize < 100);
+      assertEquals(i + 1, closedThreads.get() + fallbackSize);
+    }
+    assertEquals(0, failures.get());
+  }
+
+  private void checkFailure(AtomicInteger failures) {
+    if (Thread.currentThread().getId() != threadLocal.get()) {
+      failures.incrementAndGet();
+    }
+  }
+}


### PR DESCRIPTION
This prevents needlessly duplicating too many
internal objects inside ThreadLocalSparkeyReader
when it's being used from ForkJoinPool.commonPool
in Java17+