### PR TITLE
Bump java-merge-sort

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <dependency>
       <groupId>com.fasterxml.util</groupId>
       <artifactId>java-merge-sort</artifactId>
-      <version>1.0.1</version>
+      <version>1.1.0</version>
     </dependency>
 
     <!-- https://search.maven.org/artifact/org.xerial.snappy/snappy-java/1.1.7.2/bundle-->


### PR DESCRIPTION
Addresses security vulnerability:
* https://www.cve.org/CVERecord?id=CVE-2022-24913
* https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLUTIL-3227926